### PR TITLE
Added support for extending templates

### DIFF
--- a/Sources/StencilRenderer.swift
+++ b/Sources/StencilRenderer.swift
@@ -1,4 +1,5 @@
 import Stencil
+import PathKit
 import Vapor
 
 public class StencilRenderer: RenderDriver {
@@ -7,10 +8,12 @@ public class StencilRenderer: RenderDriver {
 		//empty
 	}
 
-    public func render(template template: String, context: [String: Any]) throws -> String {
-        let c = Context(dictionary: context)
-        let template = Template(templateString: template)
-        return try template.render(c)
-    }
-    
+	public func render(template template: String, context: [String: Any]) throws -> String {
+		let c = Context(dictionary: context)
+		c["loader"] = TemplateLoader(paths: [Path(View.resourceDir)])
+
+		let template = Template(templateString: template)
+		return try template.render(c)
+	}
+
 }


### PR DESCRIPTION
Stencil requires a "loader" context var set to TemplateLoader in order for `{% extends "layout.stencil" %}` to work, otherwise it throws a "Template loader not in context" error.